### PR TITLE
feat(frontend): add Warehouses and Inventory pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,8 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { LoginPage } from '@/pages/LoginPage'
 import { DashboardPage } from '@/pages/DashboardPage'
 import { ProductsPage } from '@/pages/ProductsPage'
+import { WarehousesPage } from '@/pages/WarehousesPage'
+import { InventoryPage } from '@/pages/InventoryPage'
 import './index.css'
 
 function App() {
@@ -10,6 +12,8 @@ function App() {
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/products" element={<ProductsPage />} />
+        <Route path="/warehouses" element={<WarehousesPage />} />
+        <Route path="/inventory" element={<InventoryPage />} />
         <Route path="/" element={<DashboardPage />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -7,12 +7,12 @@ export function DashboardPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 to-slate-800 p-8">
-      <div className="max-w-4xl mx-auto">
+      <div className="max-w-5xl mx-auto">
         <h1 className="text-4xl font-bold text-white mb-8">
           SmartSupply AI 📦
         </h1>
         
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           <Card className="bg-slate-800/50 border-slate-700">
             <CardHeader>
               <CardTitle className="text-white">Products</CardTitle>
@@ -27,6 +27,42 @@ export function DashboardPage() {
                 onClick={() => navigate('/products')}
               >
                 View Products
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-slate-800/50 border-slate-700">
+            <CardHeader>
+              <CardTitle className="text-white">Warehouses</CardTitle>
+              <CardDescription className="text-slate-400">
+                Manage storage locations
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button 
+                variant="secondary" 
+                className="w-full"
+                onClick={() => navigate('/warehouses')}
+              >
+                View Warehouses
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-slate-800/50 border-slate-700">
+            <CardHeader>
+              <CardTitle className="text-white">Inventory</CardTitle>
+              <CardDescription className="text-slate-400">
+                Track stock levels
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button 
+                variant="secondary" 
+                className="w-full"
+                onClick={() => navigate('/inventory')}
+              >
+                View Inventory
               </Button>
             </CardContent>
           </Card>

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+interface InventoryItem {
+  id: string
+  productId: string
+  productSku: string
+  productName: string
+  warehouseId: string
+  warehouseName: string
+  quantity: number
+  reserved: number
+  available: number
+  lastUpdated: string
+}
+
+export function InventoryPage() {
+  const navigate = useNavigate()
+  const [inventory, setInventory] = useState<InventoryItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    fetchInventory()
+  }, [])
+
+  const fetchInventory = async () => {
+    try {
+      const res = await fetch('http://localhost:8080/inventory')
+      if (!res.ok) throw new Error('Failed to fetch inventory')
+      const data = await res.json()
+      setInventory(data.content || [])
+    } catch (err) {
+      setError('Failed to load inventory. Make sure the backend is running.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const getStockStatus = (item: InventoryItem) => {
+    if (item.available <= 0) return { label: 'Out of Stock', color: 'bg-red-500/20 text-red-400' }
+    if (item.quantity <= 10) return { label: 'Low Stock', color: 'bg-yellow-500/20 text-yellow-400' }
+    return { label: 'In Stock', color: 'bg-green-500/20 text-green-400' }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 to-slate-800 p-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex justify-between items-center mb-8">
+          <h1 className="text-4xl font-bold text-white">Inventory 📊</h1>
+          <div className="flex gap-4">
+            <Button variant="secondary" onClick={() => navigate('/warehouses')}>
+              View Warehouses
+            </Button>
+            <Button variant="outline" onClick={() => navigate('/')}>
+              ← Dashboard
+            </Button>
+          </div>
+        </div>
+
+        <Card className="bg-slate-800/50 border-slate-700">
+          <CardHeader>
+            <CardTitle className="text-white">Stock Levels by Location</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <p className="text-slate-400">Loading inventory...</p>
+            ) : error ? (
+              <p className="text-red-400">{error}</p>
+            ) : inventory.length === 0 ? (
+              <p className="text-slate-400">No inventory items found.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-slate-700">
+                    <TableHead className="text-slate-300">SKU</TableHead>
+                    <TableHead className="text-slate-300">Product</TableHead>
+                    <TableHead className="text-slate-300">Warehouse</TableHead>
+                    <TableHead className="text-slate-300 text-right">Quantity</TableHead>
+                    <TableHead className="text-slate-300 text-right">Reserved</TableHead>
+                    <TableHead className="text-slate-300 text-right">Available</TableHead>
+                    <TableHead className="text-slate-300">Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {inventory.map((item) => {
+                    const status = getStockStatus(item)
+                    return (
+                      <TableRow key={item.id} className="border-slate-700">
+                        <TableCell className="text-white font-mono">{item.productSku}</TableCell>
+                        <TableCell className="text-white">{item.productName}</TableCell>
+                        <TableCell className="text-slate-400">{item.warehouseName}</TableCell>
+                        <TableCell className="text-white text-right">{item.quantity}</TableCell>
+                        <TableCell className="text-orange-400 text-right">{item.reserved}</TableCell>
+                        <TableCell className="text-green-400 text-right font-medium">{item.available}</TableCell>
+                        <TableCell>
+                          <span className={`px-2 py-1 rounded text-xs font-medium ${status.color}`}>
+                            {status.label}
+                          </span>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/WarehousesPage.tsx
+++ b/frontend/src/pages/WarehousesPage.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+interface Warehouse {
+  id: string
+  name: string
+  location: string
+  type: 'PHYSICAL' | 'VIRTUAL'
+}
+
+export function WarehousesPage() {
+  const navigate = useNavigate()
+  const [warehouses, setWarehouses] = useState<Warehouse[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    fetchWarehouses()
+  }, [])
+
+  const fetchWarehouses = async () => {
+    try {
+      const res = await fetch('http://localhost:8080/warehouses')
+      if (!res.ok) throw new Error('Failed to fetch warehouses')
+      const data = await res.json()
+      setWarehouses(data || [])
+    } catch (err) {
+      setError('Failed to load warehouses. Make sure the backend is running.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 to-slate-800 p-8">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex justify-between items-center mb-8">
+          <h1 className="text-4xl font-bold text-white">Warehouses 🏭</h1>
+          <Button variant="outline" onClick={() => navigate('/')}>
+            ← Back to Dashboard
+          </Button>
+        </div>
+
+        <Card className="bg-slate-800/50 border-slate-700">
+          <CardHeader>
+            <CardTitle className="text-white">Storage Locations</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <p className="text-slate-400">Loading warehouses...</p>
+            ) : error ? (
+              <p className="text-red-400">{error}</p>
+            ) : warehouses.length === 0 ? (
+              <p className="text-slate-400">No warehouses found.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-slate-700">
+                    <TableHead className="text-slate-300">Name</TableHead>
+                    <TableHead className="text-slate-300">Location</TableHead>
+                    <TableHead className="text-slate-300">Type</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {warehouses.map((warehouse) => (
+                    <TableRow key={warehouse.id} className="border-slate-700">
+                      <TableCell className="text-white font-medium">{warehouse.name}</TableCell>
+                      <TableCell className="text-slate-400">{warehouse.location}</TableCell>
+                      <TableCell>
+                        <span className={`px-2 py-1 rounded text-xs font-medium ${
+                          warehouse.type === 'PHYSICAL' 
+                            ? 'bg-blue-500/20 text-blue-400' 
+                            : 'bg-purple-500/20 text-purple-400'
+                        }`}>
+                          {warehouse.type}
+                        </span>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Adds Warehouses and Inventory pages to the frontend for viewing stock data.

## Changes
### New Pages
- **WarehousesPage** (`/warehouses`) - Displays all warehouses with type badges (PHYSICAL/VIRTUAL)
- **InventoryPage** (`/inventory`) - Shows stock levels with status indicators

### Updated
- **DashboardPage** - Now has 4 navigation cards (Products, Warehouses, Inventory, Login)
- **App.tsx** - Added routes for new pages

## Features
- Stock status indicators: 🟢 In Stock | 🟡 Low Stock | 🔴 Out of Stock
- Warehouse type badges: PHYSICAL / VIRTUAL
- Navigation between all pages

## Testing
1. Run backend: `cd backend-java && mvn spring-boot:run`
2. Run frontend: `cd frontend && npm run dev`
3. Open http://localhost:5173
4. Click through Dashboard → Warehouses → Inventory

Closes #20 